### PR TITLE
[제이든] step-1 체스 프로젝트 시작

### DIFF
--- a/src/main/java/Pawn.java
+++ b/src/main/java/Pawn.java
@@ -1,0 +1,13 @@
+public class Pawn {
+
+    private final String color;
+
+    public Pawn(String color) {
+        this.color = color;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+}

--- a/src/test/java/PawnTest.java
+++ b/src/test/java/PawnTest.java
@@ -1,0 +1,21 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.*;
+
+
+class PawnTest {
+
+    @Test
+    @DisplayName("pawn 생성 테스트")
+    void createPawn() {
+
+        verifyPawn("white");
+        verifyPawn("black");
+    }
+
+    void verifyPawn(final String color) {
+        Pawn pawn = new Pawn(color);
+        assertThat(pawn.getColor()).isEqualTo(color);
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
- 체스에서 Pawn의 역할을 하는 Pawn 클래스를 구현했고 String값으로 색을 할당할 수 있습니다.
- Pawn객체를 생성하고 색을 할당하는 테스트 코드를 구현했습니다.

## 고민 사항
- Pawn의 색을 어떤 type으로 저장할지 가장 많이 고민 했습니다. 
    -  char형을 사용할 경우 -> b, w라고 표현할 수 있지만 다른 char값이 들어갈 수 있기 때문에 말의 색을 나타내기에는 변수가 너무 많다고 생각했습니다.
    - String을 사용할 경우 -> black, white라고 표현할 수 있지만 String이기 때문에 null값이나 다른 더 긴 문자열이 할당될 수 있다고 생각합니다.
    - enum을 이용할 경우 -> 현재 step1에서는 Pawn클래스만 사용하기 때문에 위 코드에서는 String으로 color을 표현했습니다. 그러나  enum클래스에 BLACK과 WHITE를 선언해서 사용하면 String이나 char에 비해서 잘못된 값이 할당되는 상황이 가장 적게 발생할 것입니다.

