### PR TITLE
[실브] step-1 체스 프로젝트 시작

### DIFF
--- a/src/main/java/Pawn.java
+++ b/src/main/java/Pawn.java
@@ -1,0 +1,12 @@
+public class Pawn {
+
+    private final String color;
+
+    public Pawn(String color) {
+        this.color = color;
+    }
+
+    public String getColor() {
+        return color;
+    }
+}

--- a/src/test/java/PawnTest.java
+++ b/src/test/java/PawnTest.java
@@ -1,0 +1,22 @@
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PawnTest {
+
+    @Test
+    @DisplayName("지정된 색상의 폰이 생성되어야 한다.")
+    void create() {
+        final String white = "white";
+        final String black = "black";
+
+        verifyPawn(white);
+        verifyPawn(black);
+    }
+
+    void verifyPawn(final String color) {
+        Pawn pawn = new Pawn(color);
+        assertThat(pawn.getColor()).isEqualTo(color);
+    }
+}


### PR DESCRIPTION
## 구현 내용
- Pawn 클래스 생성
  - 생성자 및 색상 필드의 getter 구현
- PawnTest 테스트 생성
  - Pawn 생성 테스트 구현 : 생성자의 매개변수인 색상이 알맞게 필드에 저장되는지 검증

## 고민 사항
- 테스트 코드를 리팩토링할 때 로컬 변수명 대/소문자 지정
- 테스트 코드의 중복 부분을 구현한 메소드의 매개변수 final 추가

## 설계내용
Pawn 클래스는 체스 게임에서 가장 기본적인 말인 폰을 나타내는 클래스입니다. 각 폰은 특정 색깔(흰색 또는 검은색)을 가지며, 해당 색깔을 기반으로 구별됩니다.

- 속성
  - color : 폰의 색깔을 나타내는 문자열 ("white" 또는 "black" 중 하나의 값을 가짐)
- 메서드
  - Pawn(String color) : 주어진 색깔로 폰 객체 생성
  - getColor() : 폰의 색깔 반환