### PR TITLE
[그로밋] step-3 체스판 초기화.

### DIFF
--- a/chess1/src/main/java/chess/Application.java
+++ b/chess1/src/main/java/chess/Application.java
@@ -1,0 +1,38 @@
+package chess;
+
+import java.util.Scanner;
+import java.util.stream.Stream;
+
+public class Application {
+    public static void main(String[] args) {
+        final Scanner scanner = new Scanner(System.in);
+
+        while (true) {
+            System.out.print("start : 게임 시작, end : 종료\n");
+            final String command = scanner.next();
+            final InputType type = InputType.match(command);
+            if (type == InputType.start) {
+                final Board board = new Board();
+                final Board initBoard = board.initialize();
+                initBoard.print();
+            }
+            if (type == InputType.Continue) {
+                System.out.println("다시 입력해주세요.");
+            }
+            if (type == InputType.end) {
+                break;
+            }
+        }
+    }
+
+    private enum InputType {
+        start, end, Continue;
+
+        private static InputType match(final String command) {
+            return Stream.of(values())
+                    .filter(type -> type.toString().equals(command))
+                    .findFirst()
+                    .orElse(Continue);
+        }
+    }
+}

--- a/chess1/src/main/java/chess/Board.java
+++ b/chess1/src/main/java/chess/Board.java
@@ -30,12 +30,9 @@ public class Board {
     }
 
     Board initialize() {
-        Function<Integer, Pawn> whitePawns = i -> Pawn.createWhitePawn();
-        Function<Integer, Pawn> blackPawns = i -> Pawn.createBlackPawn();
-
-        List<Pawn> pawns = Stream.concat(
-                IntStream.rangeClosed(1, 8).mapToObj(whitePawns::apply),
-                IntStream.rangeClosed(1, 8).mapToObj(blackPawns::apply)
+        final List<Pawn> pawns = Stream.concat(
+                IntStream.rangeClosed(1, 8).mapToObj(i -> Pawn.createWhitePawn()),
+                IntStream.rangeClosed(1, 8).mapToObj(i -> Pawn.createBlackPawn())
         ).toList();
         return new Board(pawns);
     }

--- a/chess1/src/main/java/chess/Board.java
+++ b/chess1/src/main/java/chess/Board.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -36,6 +37,33 @@ public class Board {
         return new Board(blackPawns);
     }
 
+    void print() {
+        final String blankRow = ".".repeat(8);
+        final StringBuilder boardState = new StringBuilder();
+        boardState.append(blankRow).append("\n")
+                .append(getBlackPawnsResult()).append("\n")
+                .append(blankRow).append("\n")
+                .append(blankRow).append("\n")
+                .append(blankRow).append("\n")
+                .append(blankRow).append("\n")
+                .append(getWhitePawnsResult()).append("\n")
+                .append(blankRow).append("\n");
+        System.out.println(boardState);
+    }
+
+    private String getWhitePawnsResult() {
+        return pawns.stream()
+                .filter(pawn -> !pawn.isBlack())
+                .map(pawn -> "p")
+                .collect(Collectors.joining());
+    }
+
+    private String getBlackPawnsResult() {
+        return pawns.stream()
+                .filter(Pawn::isBlack)
+                .map(pawn -> "P")
+                .collect(Collectors.joining());
+    }
 
 
     Board add(final Pawn pawn) {

--- a/chess1/src/main/java/chess/Board.java
+++ b/chess1/src/main/java/chess/Board.java
@@ -2,8 +2,17 @@ package chess;
 
 import chess.pieces.Pawn;
 
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.sql.Array;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Board {
     private final List<Pawn> pawns;
@@ -15,6 +24,19 @@ public class Board {
     private Board(final List<Pawn> pawns) {
         this.pawns = pawns;
     }
+
+    Board initialize() {
+        final List<Pawn> blackPawns = IntStream.rangeClosed(1, 8)
+                .mapToObj(i -> Pawn.createBlackPawn())
+                .collect(Collectors.toList());
+        final List<Pawn> whitePawns = IntStream.rangeClosed(1, 8)
+                .mapToObj(i -> Pawn.createWhitePawn())
+                .toList();
+        blackPawns.addAll(whitePawns);
+        return new Board(blackPawns);
+    }
+
+
 
     Board add(final Pawn pawn) {
         final List<Pawn> adding = new ArrayList<>(pawns);

--- a/chess1/src/main/java/chess/Board.java
+++ b/chess1/src/main/java/chess/Board.java
@@ -1,5 +1,6 @@
 package chess;
 
+import chess.pieces.Color;
 import chess.pieces.Pawn;
 
 import java.io.BufferedReader;
@@ -9,11 +10,13 @@ import java.sql.Array;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 public class Board {
     private final List<Pawn> pawns;
@@ -27,14 +30,14 @@ public class Board {
     }
 
     Board initialize() {
-        final List<Pawn> blackPawns = IntStream.rangeClosed(1, 8)
-                .mapToObj(i -> Pawn.createBlackPawn())
-                .collect(Collectors.toList());
-        final List<Pawn> whitePawns = IntStream.rangeClosed(1, 8)
-                .mapToObj(i -> Pawn.createWhitePawn())
-                .toList();
-        blackPawns.addAll(whitePawns);
-        return new Board(blackPawns);
+        Function<Integer, Pawn> whitePawns = i -> Pawn.createWhitePawn();
+        Function<Integer, Pawn> blackPawns = i -> Pawn.createBlackPawn();
+
+        List<Pawn> pawns = Stream.concat(
+                IntStream.rangeClosed(1, 8).mapToObj(whitePawns::apply),
+                IntStream.rangeClosed(1, 8).mapToObj(blackPawns::apply)
+        ).toList();
+        return new Board(pawns);
     }
 
     void print() {

--- a/chess1/src/main/java/chess/Board.java
+++ b/chess1/src/main/java/chess/Board.java
@@ -1,19 +1,9 @@
 package chess;
 
-import chess.pieces.Color;
 import chess.pieces.Pawn;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.IOException;
-import java.sql.Array;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;

--- a/chess1/src/main/java/chess/pieces/Pawn.java
+++ b/chess1/src/main/java/chess/pieces/Pawn.java
@@ -16,6 +16,10 @@ public class Pawn {
         return new Pawn(Color.BLACK);
     }
 
+    public boolean isSameColor(final Color color) {
+        return this.color == color;
+    }
+
     public boolean isBlack() {
         return color == Color.BLACK;
     }

--- a/chess1/src/main/java/chess/pieces/Pawn.java
+++ b/chess1/src/main/java/chess/pieces/Pawn.java
@@ -3,6 +3,7 @@ package chess.pieces;
 public class Pawn {
     private final Color color;
 
+
     private Pawn(final Color color) {
         this.color = color;
     }
@@ -15,7 +16,7 @@ public class Pawn {
         return new Pawn(Color.BLACK);
     }
 
-//    public Color getColor() {
-//        return color;
-//    }
+    public boolean isBlack() {
+        return color == Color.BLACK;
+    }
 }

--- a/chess1/src/test/java/chess/BoardTest.java
+++ b/chess1/src/test/java/chess/BoardTest.java
@@ -41,5 +41,11 @@ public class BoardTest {
         assertThat(found).isEqualTo(black);
     }
 
+    @Test
+    @DisplayName("체스 판을 초기화 하면 흰색 폰 8개와 검은색 폰8개가 생성되어 총 16개가 된다")
+    void initialize() {
+        final Board initBoard = board.initialize();
 
+        assertThat(initBoard.size()).isEqualTo(16);
+    }
 }

--- a/chess1/src/test/java/chess/BoardTest.java
+++ b/chess1/src/test/java/chess/BoardTest.java
@@ -43,9 +43,16 @@ public class BoardTest {
 
     @Test
     @DisplayName("체스 판을 초기화 하면 흰색 폰 8개와 검은색 폰8개가 생성되어 총 16개가 된다")
-    void initialize() {
+    void initializedBoardHas16Pawn() {
         final Board initBoard = board.initialize();
 
         assertThat(initBoard.size()).isEqualTo(16);
+    }
+
+    @Test
+    @DisplayName("초기화 한 체스 판의 상태를 확인한다.")
+    void checkStateOfInitializedBoard() {
+        final Board initBoard = board.initialize();
+        initBoard.print();
     }
 }

--- a/chess1/src/test/java/chess/BoardTest.java
+++ b/chess1/src/test/java/chess/BoardTest.java
@@ -5,10 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BoardTest {

--- a/chess1/src/test/java/chess/BoardTest.java
+++ b/chess1/src/test/java/chess/BoardTest.java
@@ -4,32 +4,28 @@ import chess.pieces.Pawn;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BoardTest {
-
-    private Board initBoard;
-    private Pawn white;
-    private Pawn black;
+    private Board board;
 
     @BeforeEach
     @DisplayName("초기 체스 판을 생성")
     void create(){
-        initBoard = new Board();
-        white = Pawn.createWhitePawn();
-        black = Pawn.createBlackPawn();
+        board = new Board();
     }
 
     @Test
-    @DisplayName("폰이 추가될 때마다 체스 판의 크기는 1만큼 증가한다")
+    @DisplayName("폰이 3개 추가되면 체스 판의 크기는 3이다.")
     void increaseBoardSizeByAddingPawn() {
-        final Board onePiece = initBoard.add(white);
-        final Board twoPiece = onePiece.add(black);
-        final Board threePiece = twoPiece.add(black);
+        final Board onePiece = board.add(Pawn.createWhitePawn());
+        final Board twoPiece = onePiece.add(Pawn.createBlackPawn());
+        final Board threePiece = twoPiece.add(Pawn.createBlackPawn());
 
         assertThat(threePiece.size()).isEqualTo(3);
     }
@@ -37,11 +33,13 @@ public class BoardTest {
     @Test
     @DisplayName("체스 판의 목록을 얻어와 추가한 폰을 찾는다.")
     void findPawnByPosition() {
-        final Board onePiece = initBoard.add(black);
-        final Board twoPiece = onePiece.add(white);
+        Pawn black = Pawn.createBlackPawn();
+        final Board onePiece = board.add(black);
 
         final Pawn found = onePiece.findPawn(0);
 
         assertThat(found).isEqualTo(black);
     }
+
+
 }

--- a/chess1/src/test/java/chess/pieces/PawnTest.java
+++ b/chess1/src/test/java/chess/pieces/PawnTest.java
@@ -2,18 +2,26 @@ package chess.pieces;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PawnTest {
 
     @Test
-    @DisplayName("폰 색깔은 흰색과 검정색이다.")
-    void createPawn() {
+    @DisplayName("흰색 폰의 색깔은 흰색이다.")
+    void createWhitePawn() {
         Pawn white = Pawn.createWhitePawn();
+
+        assertThat(white.isSameColor(Color.WHITE)).isTrue();
+    }
+
+    @Test
+    @DisplayName("검은색 폰의 색깔은 검은색이다.")
+    void createBlackPawn3() {
         Pawn black = Pawn.createBlackPawn();
 
-        assertThat(white).extracting("color").isEqualTo(Color.WHITE);
-        assertThat(black).extracting("color").isEqualTo(Color.BLACK);
+        assertThat(black.isSameColor(Color.BLACK)).isTrue();
     }
 }

--- a/chess1/src/test/java/chess/pieces/PawnTest.java
+++ b/chess1/src/test/java/chess/pieces/PawnTest.java
@@ -2,8 +2,6 @@ package chess.pieces;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
## 구현 내용
* P와 p를 도메인 영역이 아닌 뷰 영역으로 생각해서 P와 p를 폰 객체가 관리하지 않게 만들었습니다. 그래서, `getWhitePawnsResult` 메서드의 접근제어자는 `private` 이 되었고, `private`메서드를 테스트를 하는 것이 어려워져서 콘솔에 출력해서 검증하게 되었습니다.
## 고민 사항
* `initialize` 기능을 구현할 때, 기존에 구현했던 `add` 메서드를 사용해야 하나 말아야 하나 고민이 있었습니다. 처음에는 `add` 메서드를 사용하고자 `add` 메서드를 리팩토링해서 `initialize` 메서드 내부에서 `add` 메서드를 호출하려 했지만, 후에 있을 다음 스텝들에서 `add` 메서드가 필요할 순간이 있을 것도 같다는 생각에 `add` 메서드를 리팩토링 않았고, `initialize` 를 `add`메서드와 관련없이 기능을 구현하게 되었습니다.
## 기타
* 처음 step3 를 PR 했을 때, conflict 가 일어나서 yelly의 도움을 받아 해결하게 되었습니다. upstream에 merge된 feature2 브랜치가 local 의 Gromit 브랜치에 rebase가 되지 않은채로 Gromit 브랜치에서 feature3 브랜치를 파고 작업한것이 원인이었습니다. yelly 의 도움으로 local과  upstream 을 동기화했고, local 에 새 브랜치 step3 를 판 후, feature3 의 커밋들을 step3 로 cherry-pick 을 이용해서 해결하게 되었습니다. (yelly 는 고,,수,,)