### PR TITLE
[웨이드] step-3 체스판 초기화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ replay_pid*
 .idea
 .gradle
 build
-gradle

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,0 +1,12 @@
+import java.util.Scanner;
+
+public class Main {
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+
+        while (true) {
+            String input = scanner.nextLine();
+        }
+    }
+}

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -8,9 +8,11 @@ import java.util.List;
 public class Board {
 
     private final List<Pawn> pawns;
+    private final List<List<String>> board;
 
     public Board() {
         this.pawns = new ArrayList<>();
+        this.board = new ArrayList<>();
     }
 
     public void addPawn(Pawn pawn) {
@@ -23,5 +25,38 @@ public class Board {
 
     public Pawn findPawn(int index) {
         return pawns.get(index);
+    }
+
+    public void initialize() {
+        List<String> basicLine = getBasicLine();
+        for (int i = 0; i < 8; i++) {
+            board.add(basicLine);
+        }
+        board.set(1, getWhitePawns());
+        board.set(6, getBlackPawns());
+    }
+
+    private List<String> getBasicLine() {
+        List<String> basic = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            basic.add("-");
+        }
+        return basic;
+    }
+
+    private List<String> getWhitePawns() {
+        List<String> whitePawns = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            whitePawns.add(Pawn.WHITE_REPRESENTATION);
+        }
+        return whitePawns;
+    }
+
+    private List<String> getBlackPawns() {
+        List<String> blackPawns = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            blackPawns.add(Pawn.BLACK_REPRESENTATION);
+        }
+        return blackPawns;
     }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -59,4 +59,15 @@ public class Board {
         }
         return blackPawns;
     }
+
+    public String print() {
+        StringBuilder result = new StringBuilder();
+        for (List<String> line : board) {
+            for (String element : line) {
+                result.append(element);
+            }
+            result.append("\n");
+        }
+        return result.toString();
+    }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -70,4 +70,8 @@ public class Board {
         }
         return result.toString();
     }
+
+    public List<List<String>> getBoard() {
+        return board;
+    }
 }

--- a/src/main/java/chess/Board.java
+++ b/src/main/java/chess/Board.java
@@ -32,8 +32,8 @@ public class Board {
         for (int i = 0; i < 8; i++) {
             board.add(basicLine);
         }
-        board.set(1, getWhitePawns());
-        board.set(6, getBlackPawns());
+        board.set(1, getBlackPawns());
+        board.set(6, getWhitePawns());
     }
 
     private List<String> getBasicLine() {

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -23,7 +23,7 @@ public class Pawn {
         }
     }
 
-    public String getColor() {
-        return color;
+    public boolean verifyPawn(final String color) {
+        return this.color.equals(color);
     }
 }

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -4,17 +4,26 @@ public class Pawn {
 
     public static final String WHITE_COLOR = "white";
     public static final String BLACK_COLOR = "black";
+    public static final String WHITE_REPRESENTATION = "p";
+    public static final String BLACK_REPRESENTATION = "P";
     private static final String COLOR_ERROR_MESSAGE = "[ERROR] 색상은 white 혹은 black만 가능합니다.";
 
     private final String color;
+    private final String representation;
 
     public Pawn() {
         this.color = WHITE_COLOR;
+        this.representation = WHITE_REPRESENTATION;
     }
 
     public Pawn(String color) {
         validate(color);
         this.color = color;
+        if (color.equals("white")) {
+            this.representation = WHITE_REPRESENTATION;
+        } else {
+            this.representation = BLACK_REPRESENTATION;
+        }
     }
 
     private void validate(String color) {
@@ -25,5 +34,9 @@ public class Pawn {
 
     public boolean verifyPawn(final String color) {
         return this.color.equals(color);
+    }
+
+    public boolean verifyRepresentation(final String representation) {
+        return this.representation.equals(representation);
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -1,10 +1,13 @@
 package chess;
 
 import chess.pieces.Pawn;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BoardTest {
 
@@ -23,19 +26,35 @@ public class BoardTest {
     @DisplayName("체스판에 저장된 폰의 수를 확인합니다.")
     public void verifyNumberOfPawnsOnBoard() {
         board.addPawn(white);
-        Assertions.assertThat(board.getPawnsSize()).isEqualTo(1);
+        assertThat(board.getPawnsSize()).isEqualTo(1);
 
         board.addPawn(black);
-        Assertions.assertThat(board.getPawnsSize()).isEqualTo(2);
+        assertThat(board.getPawnsSize()).isEqualTo(2);
     }
 
     @Test
     @DisplayName("체스판에 저장된 객체를 확인합니다.")
     public void verifyStoredPawnObjectsOnBoard() {
         board.addPawn(white);
-        Assertions.assertThat(board.findPawn(0)).isEqualTo(white);
+        assertThat(board.findPawn(0)).isEqualTo(white);
 
         board.addPawn(black);
-        Assertions.assertThat(board.findPawn(1)).isEqualTo(black);
+        assertThat(board.findPawn(1)).isEqualTo(black);
+    }
+
+    @Test
+    @DisplayName("체스판을 초기화하면 2, 7번째 줄에 각각 흰색 폰 Line, 검은색 폰 Line이 생성됩니다.")
+    void verifyPawnsOnTheBoardAfterInitializeBoard() {
+        board.initialize();
+        List<List<String>> chessBoard = board.getBoard();
+        assertThat(chessBoard.get(1)).isEqualTo(List.of("p", "p", "p", "p", "p", "p", "p", "p"));
+        assertThat(chessBoard.get(6)).isEqualTo(List.of("P", "P", "P", "P", "P", "P", "P", "P"));
+    }
+
+    @Test
+    @DisplayName("현재 체스판의 상태를 출력합니다.")
+    void printCurrentBoardStatus() {
+        board.initialize();
+        System.out.println(board.print());
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -2,24 +2,40 @@ package chess;
 
 import chess.pieces.Pawn;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class BoardTest {
 
-    @Test
-    @DisplayName("폰 객체를 체스판에 추가하고, 저장된 폰의 수와 저장된 객체를 확인합니다.")
-    public void verifyResultOfAddingPawnToBoard() {
-        Board board = new Board();
+    private Board board;
+    private Pawn white;
+    private Pawn black;
 
-        Pawn white = new Pawn(Pawn.WHITE_COLOR);
+    @BeforeEach
+    void setUp() {
+        board = new Board();
+        white = new Pawn(Pawn.WHITE_COLOR);
+        black = new Pawn(Pawn.BLACK_COLOR);
+    }
+
+    @Test
+    @DisplayName("체스판에 저장된 폰의 수를 확인합니다.")
+    public void verifyNumberOfPawnsOnBoard() {
         board.addPawn(white);
         Assertions.assertThat(board.getPawnsSize()).isEqualTo(1);
-        Assertions.assertThat(board.findPawn(0)).isEqualTo(white);
 
-        Pawn black = new Pawn(Pawn.BLACK_COLOR);
         board.addPawn(black);
         Assertions.assertThat(board.getPawnsSize()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("체스판에 저장된 객체를 확인합니다.")
+    public void verifyStoredPawnObjectsOnBoard() {
+        board.addPawn(white);
+        Assertions.assertThat(board.findPawn(0)).isEqualTo(white);
+
+        board.addPawn(black);
         Assertions.assertThat(board.findPawn(1)).isEqualTo(black);
     }
 }

--- a/src/test/java/chess/BoardTest.java
+++ b/src/test/java/chess/BoardTest.java
@@ -47,8 +47,8 @@ public class BoardTest {
     void verifyPawnsOnTheBoardAfterInitializeBoard() {
         board.initialize();
         List<List<String>> chessBoard = board.getBoard();
-        assertThat(chessBoard.get(1)).isEqualTo(List.of("p", "p", "p", "p", "p", "p", "p", "p"));
-        assertThat(chessBoard.get(6)).isEqualTo(List.of("P", "P", "P", "P", "P", "P", "P", "P"));
+        assertThat(chessBoard.get(1)).isEqualTo(List.of("P", "P", "P", "P", "P", "P", "P", "P"));
+        assertThat(chessBoard.get(6)).isEqualTo(List.of("p", "p", "p", "p", "p", "p", "p", "p"));
     }
 
     @Test

--- a/src/test/java/chess/pieces/PawnTest.java
+++ b/src/test/java/chess/pieces/PawnTest.java
@@ -12,14 +12,18 @@ public class PawnTest {
     @DisplayName("흰색 폰이 정상적으로 생성되어야 합니다.")
     void createPawnByWhiteColor() {
         String color = Pawn.WHITE_COLOR;
-        assertThat(new Pawn(color).verifyPawn(color)).isTrue();
+        Pawn pawn = new Pawn(color);
+        assertThat(pawn.verifyPawn(color)).isTrue();
+        assertThat(pawn.verifyRepresentation(Pawn.WHITE_REPRESENTATION)).isTrue();
     }
 
     @Test
     @DisplayName("검은색 폰이 정상적으로 생성되어야 합니다.")
     void createPawnByBlackColor() {
         String color = Pawn.BLACK_COLOR;
-        assertThat(new Pawn(color).verifyPawn(color)).isTrue();
+        Pawn pawn = new Pawn(color);
+        assertThat(pawn.verifyPawn(color)).isTrue();
+        assertThat(pawn.verifyRepresentation(Pawn.BLACK_REPRESENTATION)).isTrue();
     }
 
     @Test
@@ -30,8 +34,10 @@ public class PawnTest {
     }
 
     @Test
-    @DisplayName("기본 생성자로 Pawn 객체를 생성하면 색상은 흰색이어야 합니다.")
+    @DisplayName("기본 생성자로 Pawn 객체를 생성하면 흰색 폰이 생성됩니다.")
     public void createPawnBy기본생성자() {
-        assertThat(new Pawn().verifyPawn(Pawn.WHITE_COLOR)).isTrue();
+        Pawn pawn = new Pawn();
+        assertThat(pawn.verifyPawn(Pawn.WHITE_COLOR)).isTrue();
+        assertThat(pawn.verifyRepresentation(Pawn.WHITE_REPRESENTATION)).isTrue();
     }
 }

--- a/src/test/java/chess/pieces/PawnTest.java
+++ b/src/test/java/chess/pieces/PawnTest.java
@@ -9,30 +9,29 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 public class PawnTest {
 
     @Test
-    @DisplayName("흰색 혹은 검은색 폰이 정상적으로 생성되어야 합니다.")
-    void createPawnByWhiteAndBlackColor() {
+    @DisplayName("흰색 폰이 정상적으로 생성되어야 합니다.")
+    void createPawnByWhiteColor() {
         String color = Pawn.WHITE_COLOR;
-        verifyPawn(color);
-
-        color = Pawn.BLACK_COLOR;
-        verifyPawn(color);
-    }
-
-    void verifyPawn(final String color) {
-        assertThat(new Pawn(color).getColor()).isEqualTo(color);
+        assertThat(new Pawn(color).verifyPawn(color)).isTrue();
     }
 
     @Test
-    @DisplayName("흰색 혹은 검은색 폰이 아닌 경우에는 에외가 발생해야 합니다.")
-    void createPawnByNonWhiteOrNonBlackColor() {
+    @DisplayName("검은색 폰이 정상적으로 생성되어야 합니다.")
+    void createPawnByBlackColor() {
+        String color = Pawn.BLACK_COLOR;
+        assertThat(new Pawn(color).verifyPawn(color)).isTrue();
+    }
+
+    @Test
+    @DisplayName("색상이 흰색 혹은 검은색인 경우에만 폰 객체가 생성됩니다.")
+    void createPawnByNonWhiteAndNonBlackColor() {
         assertThatIllegalArgumentException()
                 .isThrownBy(() -> new Pawn("blue"));
     }
 
     @Test
-    @DisplayName("기본 생성자로 chess.pieces.Pawn 객체를 생성하면 색상은 흰색이어야 합니다.")
+    @DisplayName("기본 생성자로 Pawn 객체를 생성하면 색상은 흰색이어야 합니다.")
     public void createPawnBy기본생성자() {
-        Pawn pawn = new Pawn();
-        assertThat(pawn.getColor()).isEqualTo(Pawn.WHITE_COLOR);
+        assertThat(new Pawn().verifyPawn(Pawn.WHITE_COLOR)).isTrue();
     }
 }


### PR DESCRIPTION
## 구현 내용

- 피드백 반영
  - `gradle` 폴더를 `.gitignore`에서 제거하고 원격 저장소에 업로드 했습니다.
  - 하나의 테스트 메서드가 하나의 경우만 테스트하도록 수정했습니다.
  - getter를 사용하지 않고 Pawn 내부에  객체의 색상이 맞는지 확인하는 메서드를 생성해서 테스트를 진행했습니다.

- Pawn 클래스
  - 색상에 따른 형태(representation)를 상수로 추가했습니다.
  - 생성자에서 파라미터로 들어오는 색상에 따라 필드인 `representation`을 설정하도록 했습니다.

- Board 클래스
  - initialize() : `basicLine`을 만들어 체스판을 초기화한 후, 2, 7 번째 줄에 각각 검은색 폰의 Line, 흰색 폰의 Line을 추가합니다.
  - print() : 체스판, `List<List<String>> board`의 상태를 StringBuilder를 이용해서 String으로 변환 후, 반환합니다.

## 고민 사항

- 다른 동료의 pr에서 gradle-wrapper.jar 파일을 저장소에 올리면 안된다는 피드백을 봤습니다. 그런데 공식 문서와 구글의 내용에는 올려야 한다고 돼있어서, 상황에 따라 다른 것인지 궁금해졌습니다.  
- 하나의 경우의 수에 대한 정의에 대해 고민을 했습니다. 예를 들어 아래 코드처럼 객체 생성 테스트를 진행해도 되는 것인지, 아니면 색상 테스트와 색상 형태 테스트를 분리해야 하는 것인지 고민했습니다.
  
  ```java
  @Test
  @DisplayName("흰색 폰이 정상적으로 생성되어야 합니다.")
  void createPawnByWhiteColor() {
      String color = Pawn.WHITE_COLOR;
      Pawn pawn = new Pawn(color);
      assertThat(pawn.verifyPawn(color)).isTrue();
      assertThat(pawn.verifyRepresentation(Pawn.WHITE_REPRESENTATION)).isTrue();
  }
  ```
- getter를 사용하지 않고 Pawn 내부에 verifyPawn(final String color) 메서드를 생성해서 테스트에 사용했는데, 피드백 주신 의도에 맞는 건지 아닌지 궁금합니다.

## 기타

- 이전 step에서 merge 되기를 기다리며, 추가 작업을 진행한 후, merge가 되면 추가로 진행한 작업 커밋만을 메인(닉네임) 브랜치에 rebase하려 했던 것이 실패했었습니다. 충돌을 해결하며 진행하면 된다는 피드백을 받고, 이번 pr 이후로 다시 시도해보려 합니다.